### PR TITLE
Mudar a nomenclatura da Geração e Leitura de PPM no Guia

### DIFF
--- a/README.md
+++ b/README.md
@@ -910,8 +910,8 @@ Algumas macros interessantes de timer são:
   exemplo seria `&htim2`. Por exemplo, se quiséssemos ler o valor do timer,
   utilizaríamos `__HAL_TIM_GET_COUNTER(&htim2)`.
 
-As aplicações de timer mais utilizadas na equipe são em PWM e PPM, que serão    (aqui)
-explicadas na próxima seção.
+As aplicações de timer mais utilizadas na equipe são em PWM, que será    
+explicada na próxima seção.
 
 # PWM
 


### PR DESCRIPTION
Mudei um pouco o Guia da ST, adicionando alguma explicaçãozinha a mais e alterando PPM para PWM limitada, considerando que a teoria estava um pouco errada. Mas não sei se vale a pena trocar efetivamente já que a convenção popular é usar incorretamente PPM nesse caso.